### PR TITLE
Restore related models functions

### DIFF
--- a/lib/services.template.angular2.ejs
+++ b/lib/services.template.angular2.ejs
@@ -191,11 +191,9 @@ export class <%-: modelName %>Api extends BaseLoopBackApi {
     super(http);
   }
 <% meta.methods.forEach(function(action) {
-  if (action.internal) {
-    return;
-  }
-
+ 
   var methodName = action.name.split('.').join('$').replace('prototype$', '');
+  methodName = methodName.replace(/::/g, '__')
 -%>
 <%   ngdocForMethod(modelName, methodName, action); -%>
 <%
@@ -375,7 +373,6 @@ function ngdocForMethod(modelName, methodName, action, responseModelName) {
 <%
   if (action.internal) {
 -%>
-  // INTERNAL. <%- action.internal %>
 <%
     return;
   }


### PR DESCRIPTION
```
if (action.internal) {
   return;
}
```

remove all related model functions, example :

```
  // INTERNAL. Use Category.products.findById() instead.
  public ::findById::category::products(id: any, fk: any)
```

The :: in name produce typescript error, so I replaced :: by __
