### PR TITLE
disable tslint in generated file

### DIFF
--- a/lib/services.template.angular2.ejs
+++ b/lib/services.template.angular2.ejs
@@ -1,3 +1,4 @@
+/* tslint:disable */
 import {Injectable, Inject} from 'angular2/core';
 import {Http, Headers, Request, Response} from 'angular2/http';
 import {Observable} from 'rxjs/Observable';


### PR DESCRIPTION
Generated file rarely match tslint rules of projects.
