### PR TITLE
no crash on failed login

### DIFF
--- a/lib/services.template.angular2.ejs
+++ b/lib/services.template.angular2.ejs
@@ -269,7 +269,9 @@ if (meta.isUser && methodName === 'login') { %>
         auth.setUser(response.id, response.userId, response.user);
         auth.setRememberMe(true);
         auth.save();
-      })<%
+      },
+        err => console.warn(err)
+      )<%
 } else if (meta.isUser && methodName === 'logout') { %>
       .share();
       result.subscribe(() => {


### PR DESCRIPTION
On a failed login, angular throw :
EXCEPTION: [object Object]

console.warn error instead
