### PR TITLE
Fixed angular2 to @angular & body undefined to {}

### DIFF
--- a/lib/services.template.angular2.ejs
+++ b/lib/services.template.angular2.ejs
@@ -1,6 +1,6 @@
 /* tslint:disable */
-import {Injectable, Inject, Optional} from 'angular2/core';
-import {Http, Headers, Request, Response} from 'angular2/http';
+import {Injectable, Inject, Optional} from '@angular/core';
+import {Http, Headers, Request, Response} from '@angular/http';
 import {Observable} from 'rxjs/Observable';
 import 'rxjs/add/observable/throw';
 import 'rxjs/add/operator/map';

--- a/lib/services.template.angular2.ejs
+++ b/lib/services.template.angular2.ejs
@@ -176,7 +176,7 @@ export abstract class BaseLoopBackApi {
       headers: headers,
       method: method,
       url: requestUrl,
-      body: data ? JSON.stringify(data) : undefined
+      body: data ? JSON.stringify(data) : {}
     });
 
     return this.http.request(request)


### PR DESCRIPTION
Hi,

i've found very useful this library.

I propose changing angular2 generated references to @angular to be compatible with the new Angular2 RC versions.

Also i changed the template at line
      body: data ? JSON.stringify(data) : undefined

When i am making a request that doesn't need any parameters, defining body as undefined is crashing my app. I changed it to {} instead of undefined, and now it works.

Best regards,

J. Carlos Roldán
